### PR TITLE
Custom charge alerts

### DIFF
--- a/Paystack/PSTCKCategoryLoader.m
+++ b/Paystack/PSTCKCategoryLoader.m
@@ -13,7 +13,7 @@
 
 + (void)loadCategories {
     linkDictionaryCategory();
-    linkUIImageCategory();
+    linkUIImageCategoryPaystack();
 }
 
 @end

--- a/Paystack/PublicHeaders/PSTCKAPIClient.h
+++ b/Paystack/PublicHeaders/PSTCKAPIClient.h
@@ -11,6 +11,13 @@
 static NSString *const __nonnull PSTCKSDKVersion = @"3.0.4";
 static NSString *const __nonnull PSTCKSDKBuild = @"13";
 
+typedef NS_ENUM(NSInteger, PSTCKChargeRequestAlerts) {
+    PSTCKChargeRequestAlertsPaystack,
+    PSTCKChargeRequestAlertsCustomPin,
+    PSTCKChargeRequestAlertsCustomOtp,
+    PSTCKChargeRequestAlertsCustomAlerts
+};
+
 @class PSTCKCard, PSTCKCardParams, PSTCKTransactionParams, PSTCKToken;
 
 /**
@@ -21,7 +28,15 @@ static NSString *const __nonnull PSTCKSDKBuild = @"13";
  */
 typedef void (^PSTCKErrorCompletionBlock)(NSError * __nonnull error, NSString * __nullable reference);
 typedef void (^PSTCKTransactionCompletionBlock)(NSString * __nonnull reference);
+typedef void (^PSTCKChargeRequestCompletionBlock)(NSString * __nonnull reference);
 typedef void (^PSTCKNotifyCompletionBlock)(void);
+
+@protocol PSTCKChargeDelegate <NSObject>
+
+- (void)PSTCKCustomPinMethodWith:(PSTCKChargeRequestCompletionBlock )completion;
+- (void)PSTCKCustomOtpMethodWith:(PSTCKChargeRequestCompletionBlock )completion;
+
+@end
 
 /**
  A top-level class that imports the rest of the Paystack SDK. This class used to contain several methods to create Paystack tokens, but those are now deprecated in
@@ -44,6 +59,11 @@ typedef void (^PSTCKNotifyCompletionBlock)(void);
 
 /// A client for making connections to the Paystack API.
 @interface PSTCKAPIClient : NSObject
+
+/**
+ * A client delegate provides methods for validate pin and otp in custom controllers
+ */
+@property (weak) id<PSTCKChargeDelegate> delegate;
 
 /**
  *  A shared singleton API client. Its API key will be initially equal to [Paystack defaultPublicKey].
@@ -94,6 +114,14 @@ typedef void (^PSTCKNotifyCompletionBlock)(void);
          didEndWithError:(nonnull PSTCKErrorCompletionBlock)errorCompletion
        willPresentDialog:(nonnull PSTCKNotifyCompletionBlock)showingDialogCompletion
          dismissedDialog:(nonnull PSTCKNotifyCompletionBlock)dialogDismissedCompletion
+   didTransactionSuccess:(nonnull PSTCKTransactionCompletionBlock)successCompletion;
+
+- (void)      chargeCard:(nonnull PSTCKCardParams *)card
+          forTransaction:(nonnull PSTCKTransactionParams *)transaction
+        onViewController:(nonnull UIViewController *)viewController
+              alertsType:(PSTCKChargeRequestAlerts )state
+         didEndWithError:(nonnull PSTCKErrorCompletionBlock)errorCompletion
+    didRequestValidation:(nonnull PSTCKTransactionCompletionBlock)beforeValidateCompletion
    didTransactionSuccess:(nonnull PSTCKTransactionCompletionBlock)successCompletion;
 
 @end

--- a/Paystack/PublicHeaders/UI/UIImage+Paystack.h
+++ b/Paystack/PublicHeaders/UI/UIImage+Paystack.h
@@ -22,4 +22,4 @@
 
 @end
 
-void linkUIImageCategory(void);
+void linkUIImageCategoryPaystack(void);

--- a/Paystack/UI/UIImage+Paystack.m
+++ b/Paystack/UI/UIImage+Paystack.m
@@ -93,4 +93,4 @@
 
 @end
 
-void linkUIImageCategory(void){}
+void linkUIImageCategoryPaystack(void){}


### PR DESCRIPTION
Following changes provide new feature responsible for request PIN and OTP Alerts, User will be able to  use custom views instead standard iOS alerts. To use it please set delegate to appropriate controller and execute method:
`- (void)chargeCard:(PSTCKCardParams *)card forTransaction:(PSTCKTransactionParams *)transaction onViewController:(UIViewController *)viewController alertsType:(PSTCKChargeRequestAlerts)state didEndWithError:(PSTCKErrorCompletionBlock)errorCompletion didRequestValidation (PSTCKTransactionCompletionBlock)beforeValidateCompletion didTransactionSuccess:(PSTCKTransactionCompletionBlock)successCompletion`

 where alertsType should be nil or PSTCKChargeRequestAlertsPaystack (if user need to use SDK's alerts) or set by one of enum PSTCKChargeRequestAlerts types. 


Example usage:
1) Set delegate to object
`PSTCKAPIClient *paystackClient = [[PSTCKAPIClient alloc] init];`
  `self.paystackClient.delegate = self;`

2) Execute charge method with alertsType property 
`[self.paystackClient chargeCard:cardParams forTransaction:transaction onViewController:self.controller alertsType: PSTCKChargeRequestAlertsCustomAlerts didEndWithError:^(NSError * _Nonnull error, NSString * _Nullable reference) {
            NSLog(@"Error reference: %@", reference);
        } didRequestValidation:^(NSString * _Nonnull reference) {
            NSLog(@"Validate reference: %@", reference);
        } didTransactionSuccess:^(NSString * _Nonnull reference) {
            NSLog(@"Success reference: %@", reference);
        }];`

3) Remember to conform protocol `PSTCKChargeDelegate` in appropriate controller:
`@interface ConfirmViewModel : NSObject <PSTCKChargeDelegate>`

Example of custom UI:
```
- (void)PSTCKCustomPinMethodWith:(PSTCKChargeRequestCompletionBlock)completion {
    ViewController *modalController = [ControllerProvider provideViewControllerWithCompletion:^(UIViewController *controller, NSString *pinString) {
        [controller dismissViewControllerAnimated:YES completion:nil];
        if (completion) completion(pinString);
    }];
    
    // Show modally with navigationItem style
    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:modalController];
    navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
    [self.controller presentViewController:navigationController animated:YES completion:nil];
}
