### PR TITLE
Danger integration in primary workflow

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -6,13 +6,19 @@ on:
       branches: [ master ]
 
 jobs:
-  SwiftLint:
+  CodeQuality:
     runs-on: ubuntu-latest
+    name: Code quality Checks
+    
     steps:
-      - uses: actions/checkout@v1
-      - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.2.1
-
+     - uses: actions/checkout@v1
+     - name: Danger
+       uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.9.1
+       with:
+            args: --failOnErrors --no-publish-check
+       env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
   UnitTests:
     name: Unit Tests
     runs-on: macos-latest

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,33 @@
+// swiftlint:disable all
+import Danger
+
+fileprivate extension Danger.File {
+    var isInTests: Bool { hasPrefix("PaystackTests/") }
+    
+    var isSourceFile: Bool {
+        hasSuffix(".swift") || hasSuffix(".h") || hasSuffix(".m")
+    }
+}
+
+let danger = Danger()
+
+let hasSourceChanges = (danger.git.modifiedFiles + danger.git.createdFiles).contains { $0.isSourceFile }
+//SwiftLint
+SwiftLint.lint(configFile: ".swiftlint.yml")
+
+// Encourage smaller PRs
+let bigPRThreshold = 50
+if (danger.github.pullRequest.additions! + danger.github.pullRequest.deletions! > bigPRThreshold) {
+    warn("Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review.");
+}
+
+// Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+if danger.github?.pullRequest.title.contains("WIP") == true {
+    warn("PR is marked as Work in Progress")
+}
+
+// Warn when files has been updated but not tests.
+if hasSourceChanges && !danger.git.modifiedFiles.contains(where: { $0.isInTests }) {
+    warn("The source files were changed, but the tests remain unmodified. Consider updating or adding to the tests to match the source changes.")
+}
+


### PR DESCRIPTION
Using danger to enforce PR rules and also to run swift lint. Rules and actions added with this PR,

- Run swiftlint based on config file defined at .swiftlint.yml
- Show a warning if modified files are more than 50
- Show a warning if PR is marked as work in progress( if title contains WIP)
- Show a warning if PR has source files changed but no tests are changed