### PR TITLE
Adding Github Token as Environment Variable

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -36,6 +36,7 @@ jobs:
          
       - name: SonarCloud Analysis
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           gem install slather  


### PR DESCRIPTION
- Adding Github Token as environment variable as it is required when running on master branch for SonarScanner
