### PR TITLE
Fix for a security vulnerability in rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
+    activesupport (6.1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
@@ -24,10 +30,12 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.0.3)
+    clamp (1.3.2)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     digest-crc (0.6.3)
@@ -134,26 +142,34 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
     jwt (2.2.2)
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.1)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     os (1.1.1)
     plist (3.6.0)
     public_suffix (4.0.6)
+    racc (1.5.2)
     rake (13.0.3)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (2.0.7)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
@@ -167,6 +183,12 @@ GEM
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
+    slather (2.7.1)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (~> 1.11)
+      xcodeproj (~> 1.7)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -174,6 +196,8 @@ GEM
     tty-screen (0.8.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
@@ -191,12 +215,14 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   fastlane
+  slather
 
 BUNDLED WITH
-   2.1.2
+   2.2.16


### PR DESCRIPTION
This PR fixes a security vulnerability in rexml. Read more here: https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/