### PR TITLE
Remove running primary workflow on pushes to master

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -1,7 +1,5 @@
 name: Primary
 on:
-   push:
-      branches: [ master ]
    pull_request:
       branches: [ master ]
 


### PR DESCRIPTION
The primary workflow was set to run on pull requests and pushes to master. Running this on pushes to master was causing danger to fail since the danger step looks for a pr to enforce pr rules